### PR TITLE
Prevent duplicate user creation in Firestore

### DIFF
--- a/src/daos/UserDao.js
+++ b/src/daos/UserDao.js
@@ -1,94 +1,116 @@
-import { collection, getDoc, doc, addDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { collection, getDoc, doc, addDoc, updateDoc, deleteDoc, query, where, getDocs } from "firebase/firestore";
 import { db } from "../../firebase.config";
 
 /**
- 	* UserDao class to interact with the 'users' collection in Firestore.
- 	* Provides methods for performing CRUD (Create, Read, Update, Delete) operations
- 	* on user documents stored in Firestore.
+ * UserDao class to interact with the 'users' collection in Firestore.
+ * Provides methods for performing CRUD (Create, Read, Update, Delete) operations
+ * on user documents stored in Firestore.
  */
 class UserDao {
-	/**
-	 	* Constructor of the UserDao class.
-	 	* Creates a reference to the 'users' collection in the Firestore database.
-	 */
-	constructor() {
-		this.collectionRef = collection(db, "users")
-	}
+    /**
+     * Constructor of the UserDao class.
+     * Creates a reference to the 'users' collection in the Firestore database.
+     */
+    constructor() {
+        this.collectionRef = collection(db, "users");
+    }
 
-	/**
-	 	* Gets a user document by its ID.
-	 	*
-	 	* @async
-	 	* @function
-	 	* @param {string} id - The ID of the user to search for.
-	 	* @returns {Promise<Object>} - An object indicating the success or failure of the operation and the user data if it exists.
-	 */
-	async getUserById(id) {
-		await getDoc(doc(this.collectionRef, id))
-			.then((userDoc) => {
-				if(userDoc.exists()) {
-					return { success: true, data: userDoc.data() }
-				} else {
-					return { success: false, data: null}
-				}
-			})
-			.catch((error) => {
-				console.log("Error getting Document: ", error)
-			})
-	}
+    /**
+     * Gets a user document by its ID.
+     *
+     * @async
+     * @function
+     * @param {string} id - The ID of the user to search for.
+     * @returns {Promise<Object>} - An object indicating the success or failure of the operation and the user data if it exists.
+     */
+    async getUserById(id) {
+        try {
+            const userDoc = await getDoc(doc(this.collectionRef, id));
+            if (userDoc.exists()) {
+                return { success: true, data: userDoc.data() };
+            } else {
+                return { success: false, data: null };
+            }
+        } catch (error) {
+            console.log("Error getting Document: ", error);
+        }
+    }
 
-	/**
-		* Creates a new user in the database.
-		*
-		* @async
-		* @function
-		* @param {Object} userData - An object containing the user's data to add.
-		* @returns {Promise<void>} - A promise that resolves when the user has been successfully added.
-	 */
-	async createUser(userData) {
-		await addDoc(this.collectionRef, userData)
-			.then((docRef) => {
-				console.log("Document written with ID: ", docRef.id)
-			})
-			.catch((error) => {
-				console.error("Error adding document: ", error)
-			})
-	}
+    /**
+     * Gets a user document by its email.
+     *
+     * @async
+     * @function
+     * @param {string} email - The email of the user to search for.
+     * @returns {Promise<Object>} - An object indicating the success or failure of the operation and the user data if it exists.
+     */
+    async getUserByEmail(email) {
+        try {
+            const q = query(this.collectionRef, where("email", "==", email));
+            const querySnapshot = await getDocs(q);
+            if (!querySnapshot.empty) {
+                return { success: true, data: querySnapshot.docs[0].data() };
+            } else {
+                return { success: false, data: null };
+            }
+        } catch (error) {
+            console.error("Error getting document by email: ", error);
+        }
+    }
 
-	/**
-	 	* Updates an existing user document in the database.
-	 	*
-	 	* @async
-	 	* @function
-	 	* @param {string} id - The ID of the user to update.
-	 	* @param {Object} userData - An object containing the new user data.
-	 	* @returns {Promise<void>} - A promise that resolves when the user has been successfully updated.
-	 */
-	async updateUser(id, userData) {
-		const userRef = doc(this.collectionRef, id)
+    /**
+     * Creates a new user in the database.
+     *
+     * @async
+     * @function
+     * @param {Object} userData - An object containing the user's data to add.
+     * @returns {Promise<void>} - A promise that resolves when the user has been successfully added.
+     */
+    async createUser(userData) {
+        try {
+            const docRef = await addDoc(this.collectionRef, userData);
+            console.log("Document written with ID: ", docRef.id);
+        } catch (error) {
+            console.error("Error adding document: ", error);
+        }
+    }
 
-		await updateDoc(userRef, userData)
-			.then(console.log('Document updated successfully'))
-			.catch((error) => {
-				console.log("Error updating document: ", error)
-			})
-	}
+    /**
+     * Updates an existing user document in the database.
+     *
+     * @async
+     * @function
+     * @param {string} id - The ID of the user to update.
+     * @param {Object} userData - An object containing the new user data.
+     * @returns {Promise<void>} - A promise that resolves when the user has been successfully updated.
+     */
+    async updateUser(id, userData) {
+        const userRef = doc(this.collectionRef, id);
 
-	/**
-	 	* Deletes a user document from the database by its ID.
-	 	*
-	 	* @async
-	 	* @function
-	 	* @param {string} id - The ID of the user to delete.
-	 	* @returns {Promise<void>} - A promise that resolves when the user has been successfully deleted.
-	 */
-	async deleteUser(id) {
-		await deleteDoc(doc(this.collectionRef, id))
-			.then(console.log("Document successfully deleted"))
-			.catch((error) => {
-				console.error("Error removing document: ", error)
-			})
-	}
+        try {
+            await updateDoc(userRef, userData);
+            console.log('Document updated successfully');
+        } catch (error) {
+            console.log("Error updating document: ", error);
+        }
+    }
+
+    /**
+     * Deletes a user document from the database by its ID.
+     *
+     * @async
+     * @function
+     * @param {string} id - The ID of the user to delete.
+     * @returns {Promise<void>} - A promise that resolves when the user has been successfully deleted.
+     */
+    async deleteUser(id) {
+        try {
+            await deleteDoc(doc(this.collectionRef, id));
+            console.log("Document successfully deleted");
+        } catch (error) {
+            console.error("Error removing document: ", error);
+        }
+    }
 }
 
 export default new UserDao();

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -59,17 +59,25 @@ const Login = () => {
    		* @function useEffect
     */
 	useEffect(() => {
-		if(user) {
-			const newUser = {
-				email: user.email,
-				name: user.displayName,
-				photo: user.photoURL
+		const createUserIfNotExists = async () => {
+			if (user) {
+				const existingUser = await UserDao.getUserByEmail(user.email);
+	
+				if (!existingUser.success) {
+					const newUser = {
+						email: user.email,
+						name: user.displayName,
+						photo: user.photoURL
+					};
+	
+					await UserDao.createUser(newUser);
+				}
+				navigate('/Escene');
 			}
-
-			UserDao.createUser(newUser)
-			navigate('/Escene')
-		}
-	}, [user, navigate])
+		};
+	
+		createUserIfNotExists();
+	}, [user, navigate]);	
 
 	/**
    		* If the `loading` state is `true`, displays a text saying "Loading..."


### PR DESCRIPTION
Added a check to verify if a user with the same email already exists in the Firestore database before creating a new user. This prevents the creation of duplicate user records and ensures data integrity. The existing logic for user creation and navigation remains unchanged.